### PR TITLE
Don't redact 'Anonymous' and fix redaction bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,12 +91,12 @@ app.use(function(err, req, res, next) {
 });
 
 function redact(form) {
-  if (!form || !form.number) return form;
+  if (!form || !form.number || form.number === 'Anonymous') return form;
   const num = form.number;
 	const len = num.length;
   return {
     ...form,
-    number: num.slice(0,4) + "X".repeat(len-5) + num.slice(len-3)
+    number: num.slice(0,4) + "X".repeat(len-7) + num.slice(len-3)
   }
 }
 


### PR DESCRIPTION
Previously we were redacting 'Anonymous' to 'AnoXXXous'. That's dumb.

Also, the redaction math was wrong and adding two more Xs than we should.

PR #11 is a dup of this, but had merge issues due to being on a non-updated branch.