### PR TITLE
GET uses LIKE for queue name parameter

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,10 +12,14 @@ const pass = process.env.RDS_PASSWORD || '';
 const port = process.env.RDS_PORT || '5432';
 const apiKey = process.env.API_KEY;
 
+const Op = Sequelize.Op;
+const version = "0.3.0";
+
 if (!apiKey) {
   throw("Must specify API key");
 }
 
+console.log(`Starting HRM version ${version}`);
 console.log('Trying with: ' + [host, user].join(', '));
 const sequelize = new Sequelize('hrmdb', 'hrm', pass, {
   host: host,
@@ -52,7 +56,9 @@ app.get('/contacts', function (req, res) {
   };
   if (req.query.queueName) {
     queryObject.where = {
-      queueName: req.query.queueName
+      queueName: {
+        [Op.like]: `${req.query.queueName}%`
+      }
     };
   }
   Contact.findAll(queryObject).then(contacts => {


### PR DESCRIPTION
To address JIRA issue 30, changing search by `queueName` to work as a prefix rather than exact match, in order to support times when the helpline and queue name diverge, for example, "Admin" vs "Admin (text)" and "Admin (voice)".