### PR TITLE
Updated search contacts method

### DIFF
--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -170,6 +170,7 @@ function convertContactsToSearchResults(contacts) {
       const categories = 'TBD';
       const counselor = contact.twilioWorkerId;
       const notes = contact.rawJson.caseInformation.callSummary;
+      const { channel, conversationDuration } = contact;
 
       return {
         contactId,
@@ -181,6 +182,8 @@ function convertContactsToSearchResults(contacts) {
           categories,
           counselor,
           notes,
+          channel,
+          conversationDuration,
         },
         details: redact(contact.rawJson),
       };

--- a/tests/contact-builder.js
+++ b/tests/contact-builder.js
@@ -21,6 +21,8 @@ const defaultContact = {
       callSummary: '',
     },
   },
+  channel: '',
+  conversationDuration: null,
 };
 
 class ContactBuilder {

--- a/tests/contact-controller.test.js
+++ b/tests/contact-controller.test.js
@@ -60,6 +60,8 @@ test('Convert contacts to searchResults', async () => {
         categories: 'TBD',
         counselor: 'twilio-worker-id',
         notes: 'Lost young boy',
+        channel: '',
+        conversationDuration: null,
       },
       details: {
         ...jillSmith.rawJson,
@@ -76,6 +78,8 @@ test('Convert contacts to searchResults', async () => {
         categories: 'TBD',
         counselor: 'twilio-worker-id',
         notes: 'Young pregnant woman',
+        channel: '',
+        conversationDuration: null,
       },
       details: sarahPark.rawJson,
     },


### PR DESCRIPTION
On a POST operation against /contacts/search, channel and conversationDuration fields are added to the "overview" of each contact result.