### PR TITLE
Don't filter helplines out of list case

### DIFF
--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -40,8 +40,8 @@ const CaseController = Case => {
     if (query.helpline) {
       queryObject.where = {
         helpline: query.helpline,
-      }
-    };
+      };
+    }
 
     const { count, rows } = await Case.findAndCountAll(queryObject);
     const cases = await Promise.all(

--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -37,6 +37,11 @@ const CaseController = Case => {
       limit,
       offset,
     };
+    if (query.helpline) {
+      queryObject.where = {
+        helpline: query.helpline,
+      }
+    };
 
     const { count, rows } = await Case.findAndCountAll(queryObject);
     const cases = await Promise.all(

--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -34,9 +34,6 @@ const CaseController = Case => {
     const offset = (query.offset && parseInt(query.offset, 10)) || 0;
     const queryObject = {
       order: [['createdAt', 'DESC']],
-      where: {
-        helpline: query.helpline || '',
-      },
       limit,
       offset,
     };

--- a/tests/controllers/case-controller.test.js
+++ b/tests/controllers/case-controller.test.js
@@ -314,6 +314,19 @@ test('list cases (without contacts)', async () => {
   expect(result).toStrictEqual(expected);
 });
 
+test('list cases without helpline', async () => {
+  const findAndCountAllSpy = jest.spyOn(MockCase, 'findAndCountAll');
+  const queryParams = { limit: 20, offset: 30 };
+  await CaseController.listCases(queryParams);
+  const expectedQueryObject = {
+    order: [['createdAt', 'DESC']],
+    limit: 20,
+    offset: 30,
+  };
+
+  expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
+});
+
 test('update existing case', async () => {
   const caseId = 1;
   const caseFromDB = {


### PR DESCRIPTION
@murilovmachado we had a miscommunication on the behavior of the List Cases API.  When no helpline parameter is specified, it should return all cases.  In our frontend, [we are not specifying the helpline](https://github.com/tech-matters/flex-plugins/blob/master/plugin-hrm-form/src/services/CaseService.js#L16), and we expect that it will show all cases for every helpline in the List Case Page.

This PR is mainly to illustrate the idea.  If you think the code should be factored differently to do the same thing, please change it and change any tests necessary.  Please go ahead and deploy through production after testing that cases for all helplines are appearing.  Please look at this first thing, since helplines can't finish our testing instructions without it.  Thanks.