### PR TITLE
Return connected contacts with cases

### DIFF
--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -3,14 +3,16 @@ const { retrieveCategories, getPaginationElements } = require('./helpers');
 
 const CaseController = Case => {
   const createCase = async body => {
+    const options = { include: { association: 'connectedContacts' } };
     const caseRecord = {
       info: body.info,
       helpline: body.helpline,
       status: body.status || 'open',
       twilioWorkerId: body.twilioWorkerId,
+      connectedContacts: [],
     };
 
-    const createdCase = await Case.create(caseRecord);
+    const createdCase = await Case.create(caseRecord, options);
     return createdCase;
   };
 

--- a/models/case.js
+++ b/models/case.js
@@ -9,7 +9,7 @@ const createCaseAudit = async (CaseAudit, previousValue, newValue, transaction) 
 };
 
 const getContactIds = async caseInstance => {
-  const contacts = await caseInstance.getContacts();
+  const contacts = await caseInstance.getConnectedContacts();
   return contacts.map(contact => contact.dataValues.id);
 };
 
@@ -22,7 +22,7 @@ module.exports = (sequelize, DataTypes) => {
   });
 
   Case.associate = models => {
-    Case.hasMany(models.Contact, { foreignKey: 'caseId' });
+    Case.hasMany(models.Contact, { foreignKey: 'caseId', as: 'connectedContacts' });
     Case.hasMany(models.CaseAudit, { foreignKey: 'caseId' });
   };
 

--- a/models/contact.js
+++ b/models/contact.js
@@ -29,7 +29,7 @@ const createCaseAudit = async (
   if (!caseFromDB) return;
 
   const { CaseAudit } = contactInstance.sequelize.models;
-  const contacts = await caseFromDB.getContacts();
+  const contacts = await caseFromDB.getConnectedContacts();
   const contactsId = contacts.map(contact => contact.dataValues.id);
   const previousValue = {
     ...caseFromDB.dataValues,

--- a/tests/controllers/case-controller.test.js
+++ b/tests/controllers/case-controller.test.js
@@ -17,11 +17,13 @@ test('create case', async () => {
     status: 'open',
     info: { notes: 'Child with covid-19' },
     twilioWorkerId: 'twilio-worker-id',
+    connectedContacts: [],
   };
 
   await CaseController.createCase(caseToBeCreated);
 
-  expect(createSpy).toHaveBeenCalledWith(caseToBeCreated);
+  const options = { include: { association: 'connectedContacts' } };
+  expect(createSpy).toHaveBeenCalledWith(caseToBeCreated, options);
 });
 
 test('get existing case', async () => {

--- a/tests/controllers/case-controller.test.js
+++ b/tests/controllers/case-controller.test.js
@@ -37,7 +37,8 @@ test('get existing case', async () => {
 
   const result = await CaseController.getCase(caseId);
 
-  expect(findByPkSpy).toHaveBeenCalledWith(caseId);
+  const options = { include: { association: 'connectedContacts' } };
+  expect(findByPkSpy).toHaveBeenCalledWith(caseId, options);
   expect(result).toStrictEqual(caseFromDB);
 });
 
@@ -63,6 +64,10 @@ describe('Test listCases query params', () => {
       },
       limit: 1000,
       offset: 0,
+      include: {
+        association: 'connectedContacts',
+        required: true,
+      },
     };
 
     expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -82,6 +87,10 @@ describe('Test listCases query params', () => {
       },
       limit: 30,
       offset: 0,
+      include: {
+        association: 'connectedContacts',
+        required: true,
+      },
     };
 
     expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -101,6 +110,10 @@ describe('Test listCases query params', () => {
       },
       limit: 1000,
       offset: 30,
+      include: {
+        association: 'connectedContacts',
+        required: true,
+      },
     };
 
     expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -120,6 +133,10 @@ describe('Test listCases query params', () => {
       },
       limit: 30,
       offset: 30,
+      include: {
+        association: 'connectedContacts',
+        required: true,
+      },
     };
 
     expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -139,6 +156,10 @@ describe('Test listCases query params', () => {
       },
       limit: 1000,
       offset: 0,
+      include: {
+        association: 'connectedContacts',
+        required: true,
+      },
     };
 
     expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -156,23 +177,21 @@ test('list cases (with 1st contact, no limit/offset)', async () => {
         info: { notes: 'Child with covid-19' },
         twilioWorkerId: 'twilio-worker-id',
       },
-      getContacts() {
-        return [
-          {
-            dataValues: {
-              rawJson: {
-                childInformation: { name: { firstName: 'name', lastName: 'last' } },
-                caseInformation: {
-                  categories: {
-                    cat1: { sub1: false, sub2: true },
-                    cat2: { sub2: false, sub4: false },
-                  },
+      connectedContacts: [
+        {
+          dataValues: {
+            rawJson: {
+              childInformation: { name: { firstName: 'name', lastName: 'last' } },
+              caseInformation: {
+                categories: {
+                  cat1: { sub1: false, sub2: true },
+                  cat2: { sub2: false, sub4: false },
                 },
               },
             },
           },
-        ];
-      },
+        },
+      ],
     },
   ];
 
@@ -201,6 +220,10 @@ test('list cases (with 1st contact, no limit/offset)', async () => {
     },
     limit: 1000,
     offset: 0,
+    include: {
+      association: 'connectedContacts',
+      required: true,
+    },
   };
 
   expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -218,23 +241,21 @@ test('list cases (with 1st contact, with limit/offset)', async () => {
         info: { notes: 'Child with covid-19' },
         twilioWorkerId: 'twilio-worker-id',
       },
-      getContacts() {
-        return [
-          {
-            dataValues: {
-              rawJson: {
-                childInformation: { name: { firstName: 'name', lastName: 'last' } },
-                caseInformation: {
-                  categories: {
-                    cat1: { sub1: false, sub2: true },
-                    cat2: { sub2: false, sub4: false },
-                  },
+      connectedContacts: [
+        {
+          dataValues: {
+            rawJson: {
+              childInformation: { name: { firstName: 'name', lastName: 'last' } },
+              caseInformation: {
+                categories: {
+                  cat1: { sub1: false, sub2: true },
+                  cat2: { sub2: false, sub4: false },
                 },
               },
             },
           },
-        ];
-      },
+        },
+      ],
     },
   ];
 
@@ -263,6 +284,10 @@ test('list cases (with 1st contact, with limit/offset)', async () => {
     },
     limit: 20,
     offset: 30,
+    include: {
+      association: 'connectedContacts',
+      required: true,
+    },
   };
 
   expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -280,9 +305,7 @@ test('list cases (without contacts)', async () => {
         info: { notes: 'Child with covid-19' },
         twilioWorkerId: 'twilio-worker-id',
       },
-      getContacts() {
-        return [];
-      },
+      connectedContacts: [],
     },
   ];
 
@@ -308,6 +331,10 @@ test('list cases (without contacts)', async () => {
     },
     limit: 1000,
     offset: 0,
+    include: {
+      association: 'connectedContacts',
+      required: true,
+    },
   };
 
   expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
@@ -322,6 +349,10 @@ test('list cases without helpline', async () => {
     order: [['createdAt', 'DESC']],
     limit: 20,
     offset: 30,
+    include: {
+      association: 'connectedContacts',
+      required: true,
+    },
   };
 
   expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);

--- a/tests/models/utils.js
+++ b/tests/models/utils.js
@@ -6,7 +6,7 @@ const getMockedCaseInstance = ({ dataValues, previousValues, contactIds }) => {
     create: jest.fn(),
   };
   const getContactWithId = id => ({ dataValues: { id } });
-  const getContacts = () => contactIds.map(id => getContactWithId(id));
+  const getConnectedContacts = () => contactIds.map(id => getContactWithId(id));
   const previous = () => previousValues;
 
   return {
@@ -15,7 +15,7 @@ const getMockedCaseInstance = ({ dataValues, previousValues, contactIds }) => {
     },
     dataValues,
     previous,
-    getContacts,
+    getConnectedContacts,
   };
 };
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-281

This PR:
- Returns case object with **connectedContacts** prepopulated
- **GET /cases** only returns cases that have connected contacts (no ghost cases)