### PR TITLE
Added default activity + icon attached in activity

### DIFF
--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -23,7 +23,6 @@ function createAddNoteActivity({ previousValue, newValue, createdAt, twilioWorke
     type: ActivityTypes.addNote,
     text: newNote,
     twilioWorkerId,
-    icon: ActivityTypes.addNote,
   };
 }
 
@@ -37,17 +36,17 @@ function createConnectContactActivity(
   const newContactId = newContacts.find(contact => !previousContacts.includes(contact));
   const newContact = relatedContacts.find(contact => contact.id === newContactId);
 
-  const icon =
+  // if the type is default, send the channel the counselor entered
+  const typeOrChannel =
     type === ActivityTypes.connectContact.default
       ? newContact.rawJson.contactlessTask.channel
       : type;
 
   return {
     date: createdAt,
-    type,
+    type: typeOrChannel,
     text: newContact.rawJson.caseInformation.callSummary,
     twilioWorkerId,
-    icon,
   };
 }
 

--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -23,6 +23,7 @@ function createAddNoteActivity({ previousValue, newValue, createdAt, twilioWorke
     type: ActivityTypes.addNote,
     text: newNote,
     twilioWorkerId,
+    icon: ActivityTypes.addNote,
   };
 }
 

--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -12,6 +12,8 @@ const ActivityTypes = {
   unknown: 'unknown',
 };
 
+const isConnectContactType = type => Object.keys(ActivityTypes.connectContact).includes(type);
+
 function createAddNoteActivity({ previousValue, newValue, createdAt, twilioWorkerId }) {
   const previousNotes = (previousValue && previousValue.info && previousValue.info.notes) || [];
   const newNotes = (newValue && newValue.info && newValue.info.notes) || [];
@@ -36,18 +38,18 @@ function createConnectContactActivity(
   const newContactId = newContacts.find(contact => !previousContacts.includes(contact));
   const newContact = relatedContacts.find(contact => contact.id === newContactId);
 
-  // if the type is default, send the channel the counselor entered
-  const typeOrChannel =
-    type === ActivityTypes.connectContact.default
-      ? newContact.rawJson.contactlessTask.channel
-      : type;
+  const channel =
+    type !== ActivityTypes.connectContact.default
+      ? type
+      : newContact.rawJson.contactlessTask.channel;
 
   return {
     contactId: newContactId,
     date: createdAt,
-    type: typeOrChannel,
+    type,
     text: newContact.rawJson.caseInformation.callSummary,
     twilioWorkerId,
+    channel,
   };
 }
 
@@ -83,7 +85,6 @@ function getActivityType({ previousValue, newValue }, relatedContacts) {
 
 function getActivity(caseAudit, relatedContacts) {
   const activityType = getActivityType(caseAudit, relatedContacts);
-  const isConnectContactType = type => Object.keys(ActivityTypes.connectContact).includes(type);
   let activity;
 
   if (activityType === ActivityTypes.addNote) {

--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -2,10 +2,12 @@ const ActivityTypes = {
   createCase: 'create',
   addNote: 'note',
   connectContact: {
+    voice: 'voice',
     whatsapp: 'whatsapp',
     facebook: 'facebook',
     web: 'web',
     sms: 'sms',
+    default: 'default',
   },
   unknown: 'unknown',
 };
@@ -34,11 +36,17 @@ function createConnectContactActivity(
   const newContactId = newContacts.find(contact => !previousContacts.includes(contact));
   const newContact = relatedContacts.find(contact => contact.id === newContactId);
 
+  const icon =
+    type === ActivityTypes.connectContact.default
+      ? newContact.rawJson.contactlessTask.channel
+      : type;
+
   return {
     date: createdAt,
     type,
     text: newContact.rawJson.caseInformation.callSummary,
     twilioWorkerId,
+    icon,
   };
 }
 

--- a/tests/controllers/activities.test.js
+++ b/tests/controllers/activities.test.js
@@ -94,6 +94,7 @@ describe('getActivity', () => {
 
     const activity = getActivity(caseAudit, relatedContacts);
     const expectedActivity = {
+      contactId: 1,
       date: createdAt,
       type: 'facebook',
       text: 'Child summary',

--- a/tests/controllers/activities.test.js
+++ b/tests/controllers/activities.test.js
@@ -60,6 +60,7 @@ describe('getActivity', () => {
       type: 'facebook',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',
+      channel: 'facebook',
     };
 
     expect(activity).toStrictEqual(expectedActivity);
@@ -96,9 +97,10 @@ describe('getActivity', () => {
     const expectedActivity = {
       contactId: 1,
       date: createdAt,
-      type: 'facebook',
+      type: 'default',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',
+      channel: 'facebook',
     };
 
     expect(activity).toStrictEqual(expectedActivity);

--- a/tests/controllers/activities.test.js
+++ b/tests/controllers/activities.test.js
@@ -24,7 +24,6 @@ describe('getActivity', () => {
       type: 'note',
       text: 'content',
       twilioWorkerId: 'twilio-worker-id',
-      icon: 'note',
     };
 
     expect(activity).toStrictEqual(expectedActivity);
@@ -60,7 +59,6 @@ describe('getActivity', () => {
       type: 'facebook',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',
-      icon: 'facebook',
     };
 
     expect(activity).toStrictEqual(expectedActivity);
@@ -96,10 +94,9 @@ describe('getActivity', () => {
     const activity = getActivity(caseAudit, relatedContacts);
     const expectedActivity = {
       date: createdAt,
-      type: 'default',
+      type: 'facebook',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',
-      icon: 'facebook',
     };
 
     expect(activity).toStrictEqual(expectedActivity);

--- a/tests/controllers/activities.test.js
+++ b/tests/controllers/activities.test.js
@@ -24,6 +24,7 @@ describe('getActivity', () => {
       type: 'note',
       text: 'content',
       twilioWorkerId: 'twilio-worker-id',
+      icon: 'note',
     };
 
     expect(activity).toStrictEqual(expectedActivity);
@@ -59,6 +60,7 @@ describe('getActivity', () => {
       type: 'facebook',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',
+      icon: 'facebook',
     };
 
     expect(activity).toStrictEqual(expectedActivity);

--- a/tests/controllers/activities.test.js
+++ b/tests/controllers/activities.test.js
@@ -65,4 +65,43 @@ describe('getActivity', () => {
 
     expect(activity).toStrictEqual(expectedActivity);
   });
+
+  test('default channel - facebook channel (contactless task)', () => {
+    const createdAt = '2020-30-07 18:55:20';
+    const caseAudit = {
+      createdAt,
+      twilioWorkerId: 'twilio-worker-id',
+      previousValue: {
+        contacts: [],
+      },
+      newValue: {
+        contacts: [1],
+      },
+    };
+    const relatedContacts = [
+      {
+        id: 1,
+        channel: 'default',
+        rawJson: {
+          caseInformation: {
+            callSummary: 'Child summary',
+          },
+          contactlessTask: {
+            channel: 'facebook',
+          },
+        },
+      },
+    ];
+
+    const activity = getActivity(caseAudit, relatedContacts);
+    const expectedActivity = {
+      date: createdAt,
+      type: 'default',
+      text: 'Child summary',
+      twilioWorkerId: 'twilio-worker-id',
+      icon: 'facebook',
+    };
+
+    expect(activity).toStrictEqual(expectedActivity);
+  });
 });


### PR DESCRIPTION
This PR is related to https://github.com/tech-matters/flex-plugins/pull/263

This PR adds some extra information to the activities, in order to support `default` channel (for contactless/offline tasks). Also adds a new property to the activities: `icon`, which holds the information of the icon that should be displayed in the case timeline.