### PR TITLE
Fix dates returned by referrals and contacts activities

### DIFF
--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -43,7 +43,8 @@ function createAddReferralActivity({ previousValue, newValue, createdAt, twilioW
     newReferrals[newReferrals.length - 1];
 
   return {
-    date: createdAt,
+    date: newReferral.date,
+    added: createdAt,
     type: ActivityTypes.addReferral,
     text: newReferral.referredTo,
     referral: newReferral,
@@ -52,7 +53,7 @@ function createAddReferralActivity({ previousValue, newValue, createdAt, twilioW
 }
 
 function createConnectContactActivity(
-  { previousValue, newValue, createdAt, twilioWorkerId },
+  { previousValue, newValue, twilioWorkerId },
   type,
   relatedContacts,
 ) {
@@ -68,7 +69,7 @@ function createConnectContactActivity(
 
   return {
     contactId: newContactId,
-    date: createdAt,
+    date: newContact.timeOfContact,
     type,
     text: newContact.rawJson.caseInformation.callSummary,
     twilioWorkerId,

--- a/tests/controllers/activities.test.js
+++ b/tests/controllers/activities.test.js
@@ -49,7 +49,8 @@ describe('getActivity', () => {
 
     const activity = getActivity(caseAudit, []);
     const expectedActivity = {
-      date: createdAt,
+      date: referral.date,
+      added: createdAt,
       type: 'referral',
       text: referral.referredTo,
       referral,
@@ -75,6 +76,7 @@ describe('getActivity', () => {
       {
         id: 1,
         channel: 'facebook',
+        timeOfContact: createdAt,
         rawJson: {
           caseInformation: {
             callSummary: 'Child summary',
@@ -112,6 +114,7 @@ describe('getActivity', () => {
       {
         id: 1,
         channel: 'default',
+        timeOfContact: '2021-01-07 10:00:00',
         rawJson: {
           caseInformation: {
             callSummary: 'Child summary',
@@ -126,7 +129,7 @@ describe('getActivity', () => {
     const activity = getActivity(caseAudit, relatedContacts);
     const expectedActivity = {
       contactId: 1,
-      date: createdAt,
+      date: '2021-01-07 10:00:00',
       type: 'default',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-461

Primary reviewer: @GPaoloni 

Referrals and Contacts activities were returning the date they were created as **date**. This now changed to:
- return referal's **date** as **date**
- return contact's **timeOfContact** as **date**
