### PR TITLE
Adds createdAt return for contact activity

### DIFF
--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -44,7 +44,7 @@ function createAddReferralActivity({ previousValue, newValue, createdAt, twilioW
 
   return {
     date: newReferral.date,
-    added: createdAt,
+    createdAt,
     type: ActivityTypes.addReferral,
     text: newReferral.referredTo,
     referral: newReferral,
@@ -53,7 +53,7 @@ function createAddReferralActivity({ previousValue, newValue, createdAt, twilioW
 }
 
 function createConnectContactActivity(
-  { previousValue, newValue, twilioWorkerId },
+  { previousValue, newValue, createdAt, twilioWorkerId },
   type,
   relatedContacts,
 ) {
@@ -70,6 +70,7 @@ function createConnectContactActivity(
   return {
     contactId: newContactId,
     date: newContact.timeOfContact,
+    createdAt,
     type,
     text: newContact.rawJson.caseInformation.callSummary,
     twilioWorkerId,

--- a/tests/controllers/activities.test.js
+++ b/tests/controllers/activities.test.js
@@ -50,7 +50,7 @@ describe('getActivity', () => {
     const activity = getActivity(caseAudit, []);
     const expectedActivity = {
       date: referral.date,
-      added: createdAt,
+      createdAt,
       type: 'referral',
       text: referral.referredTo,
       referral,
@@ -89,6 +89,7 @@ describe('getActivity', () => {
     const expectedActivity = {
       contactId: 1,
       date: createdAt,
+      createdAt,
       type: 'facebook',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',
@@ -130,6 +131,7 @@ describe('getActivity', () => {
     const expectedActivity = {
       contactId: 1,
       date: '2021-01-07 10:00:00',
+      createdAt,
       type: 'default',
       text: 'Child summary',
       twilioWorkerId: 'twilio-worker-id',


### PR DESCRIPTION
@GPaoloni This small backend PR does 2 things:
- renames **added** to **createdAt** (added is not the best name for the backend)
- return this **createdAt** on contact activity, so it can be on the header (just like referrals)