### PR TITLE
Added Twilio Token validator for auth

### DIFF
--- a/.github/workflows/hrm-ci.yml
+++ b/.github/workflows/hrm-ci.yml
@@ -40,4 +40,6 @@ jobs:
       env:
         CI: true
         API_KEY: secret
+        TWILIO_ACCOUNT_SID: ACxxx
+        TWILIO_AUTH_TOKEN: xxxxxx
         RDS_PASSWORD: postgres

--- a/app.js
+++ b/app.js
@@ -14,10 +14,6 @@ const accountSid = process.env.TWILIO_ACCOUNT_SID;
 const authToken = process.env.TWILIO_AUTH_TOKEN;
 const version = '0.3.6';
 
-if (!apiKey) {
-  throw new Error('Must specify API key');
-}
-
 if (!accountSid || !authToken) {
   throw new Error('Must specify Twilio credentials');
 }

--- a/app.js
+++ b/app.js
@@ -56,6 +56,7 @@ async function authorizationMiddleware(req, res, next) {
   if (!req || !req.headers || !req.headers.authorization) {
     return unauthorized(res);
   }
+  console.log('\n\n\n\n\n\n\n\n>>>>>>>>> THIS CASE');
 
   const { authorization } = req.headers;
 
@@ -68,20 +69,18 @@ async function authorizationMiddleware(req, res, next) {
       // Here we can add tokenResult (worker, roles, etc) to the req object. Is this something we want? if above code is uncomented (auth with apiKey), that can lead to confusing flows, as sometimes it will exist and sometimes not.
       return next();
     } catch (err) {
-      console.error('Token authentication failed');
+      console.error('Token authentication failed: ', err);
     }
   }
 
-  // We want to preserve this?
-
-  // else if (authorization.startsWith('Basic')) {
-  //   const base64Key = Buffer.from(authorization.replace('Basic ', ''), 'base64');
-  //   if (base64Key.toString('ascii') === apiKey) {
-  //     console.error('API Key authentication successful');
-  //     return next();
-  //   }
-  //   console.log('API Key authentication failed');
-  // }
+  // for testing we use old api key (can't hit TokenValidator api with fake credentials as it results in The requested resource /Accounts/ACxxxxxxxxxx/Tokens/validate was not found)
+  if (process.env.NODE_ENV === 'test' && authorization.startsWith('Basic')) {
+    const base64Key = Buffer.from(authorization.replace('Basic ', ''), 'base64');
+    if (base64Key.toString('ascii') === apiKey) {
+      return next();
+    }
+    console.log('API Key authentication failed');
+  }
 
   return unauthorized(res);
 }

--- a/app.js
+++ b/app.js
@@ -56,16 +56,14 @@ async function authorizationMiddleware(req, res, next) {
   if (!req || !req.headers || !req.headers.authorization) {
     return unauthorized(res);
   }
-  console.log('\n\n\n\n\n\n\n\n>>>>>>>>> THIS CASE');
 
   const { authorization } = req.headers;
 
   if (authorization.startsWith('Bearer')) {
     const token = authorization.replace('Bearer ', '');
     try {
+      // eslint-disable-next-line no-unused-vars
       const tokenResult = await TokenValidator(token, accountSid, authToken);
-      console.log('Token authentication successful');
-      console.log(tokenResult);
       // Here we can add tokenResult (worker, roles, etc) to the req object. Is this something we want? if above code is uncomented (auth with apiKey), that can lead to confusing flows, as sometimes it will exist and sometimes not.
       return next();
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7448,6 +7448,11 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "twilio-flex-token-validator": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/twilio-flex-token-validator/-/twilio-flex-token-validator-1.5.5.tgz",
+      "integrity": "sha512-vvtYMOhSN1CPGEW4Jo9TwRIM1YrhtgF+blxLsvXdqd4sKnwzbXREmAMc6ODYkwgGRcFqCQjJy88Q8ezd5KhghQ=="
+    },
     "type": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "pg-hstore": "^2.3.3",
     "sequelize": "^5.21.5",
     "sequelize-cli": "^5.5.0",
-    "swagger-ui-express": "^4.1.4"
+    "swagger-ui-express": "^4.1.4",
+    "twilio-flex-token-validator": "^1.5.5"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-394
This PR is related to https://github.com/tech-matters/flex-plugins/pull/327

This PR introduces `TokenValidator` for auth method (receives Twilio jwt token).

To test this:
- Run this repo locally, including `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` as env variables (you can look for them in Twilio console):
  `➜ TWILIO_ACCOUNT_SID=ACxxxxx TWILIO_AUTH_TOKEN=xxxxx API_KEY=whatever PORT=8080 npm run start`
- Run https://github.com/tech-matters/flex-plugins/pull/327 (changing `hrmBaseUrl` to point localhost)
- Use the normal flows of the app.

You can go further and delete `secret` constant from private folder (flex plugin), to ensure that it is in fact not being used anymore.