### PR TITLE
Bug fix: Duplicate contacts created with slow internet

### DIFF
--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -270,6 +270,12 @@ const ContactController = Contact => {
   };
 
   const createContact = async (body, accountSid) => {
+    // if a contact has been already created with this taskId, just return it (idempotence on taskId). Should we use a different HTTP code status for this case?
+    if (body.taskId) {
+      const contact = await Contact.findOne({ where: { taskId: body.taskId } });
+      if (contact) return contact;
+    }
+
     const contactRecord = {
       rawJson: body.form,
       twilioWorkerId: body.twilioWorkerId || '',
@@ -280,6 +286,7 @@ const ContactController = Contact => {
       conversationDuration: body.conversationDuration,
       accountSid: accountSid || '',
       timeOfContact: body.timeOfContact || Date.now(),
+      taskId: body.taskId || '',
     };
 
     const contact = await Contact.create(contactRecord);

--- a/migrations/20210118174350-add-taskId.js
+++ b/migrations/20210118174350-add-taskId.js
@@ -1,0 +1,9 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Contacts', 'taskId', { type: Sequelize.STRING });
+  },
+
+  down: queryInterface => {
+    return queryInterface.removeColumn('Contacts', 'taskId');
+  },
+};

--- a/models/contact.js
+++ b/models/contact.js
@@ -60,6 +60,7 @@ module.exports = (sequelize, DataTypes) => {
     conversationDuration: DataTypes.INTEGER,
     accountSid: DataTypes.STRING,
     timeOfContact: DataTypes.DATE,
+    taskId: DataTypes.STRING,
   });
 
   Contact.associate = models => Contact.belongsTo(models.Case, { foreignKey: 'caseId' });

--- a/tests/db-init/dump.sql
+++ b/tests/db-init/dump.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.9 (Ubuntu 11.9-1.pgdg18.04+1)
--- Dumped by pg_dump version 11.9 (Ubuntu 11.9-1.pgdg18.04+1)
+-- Dumped from database version 11.10 (Ubuntu 11.10-1.pgdg18.04+1)
+-- Dumped by pg_dump version 11.10 (Ubuntu 11.10-1.pgdg18.04+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -117,7 +117,8 @@ CREATE TABLE public."Contacts" (
     "conversationDuration" integer,
     "caseId" integer,
     "accountSid" character varying(255),
-    "timeOfContact" timestamp with time zone
+    "timeOfContact" timestamp with time zone,
+    "taskId" character varying(255)
 );
 
 
@@ -176,25 +177,26 @@ ALTER TABLE ONLY public."Cases" ALTER COLUMN id SET DEFAULT nextval('public."Cas
 
 ALTER TABLE ONLY public."Contacts" ALTER COLUMN id SET DEFAULT nextval('public."Contacts_id_seq"'::regclass);
 
+
 --
 -- Name: CaseAudits_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."CaseAudits_id_seq"', 2405, true);
+SELECT pg_catalog.setval('public."CaseAudits_id_seq"', 753, true);
 
 
 --
 -- Name: Cases_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."Cases_id_seq"', 1983, true);
+SELECT pg_catalog.setval('public."Cases_id_seq"', 655, true);
 
 
 --
 -- Name: Contacts_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."Contacts_id_seq"', 2555, true);
+SELECT pg_catalog.setval('public."Contacts_id_seq"', 3028, true);
 
 
 --

--- a/tests/routes/contacts.test.js
+++ b/tests/routes/contacts.test.js
@@ -15,6 +15,7 @@ const {
   another1,
   another2,
   noHelpline,
+  withTaskId,
   case1,
   case2,
 } = mocks;
@@ -70,6 +71,29 @@ describe('/contacts route', () => {
         expect(res.status).toBe(200);
         expect(res.body.rawJson.callType).toBe(contacts[index].form.callType);
       });
+    });
+
+    test('Idempotence on create contact', async () => {
+      const response = await request
+        .post(route)
+        .set(headers)
+        .send(withTaskId);
+
+      const beforeContacts = await request.get(route).set(headers);
+
+      const subsequentResponse = await request
+        .post(route)
+        .set(headers)
+        .send(withTaskId);
+
+      const afterContacts = await request.get(route).set(headers);
+
+      // both should succeed
+      expect(response.status).toBe(200);
+      expect(subsequentResponse.status).toBe(200);
+
+      // but second call should do nothing
+      expect(afterContacts.body).toHaveLength(beforeContacts.body.length);
     });
   });
 

--- a/tests/routes/mocks.js
+++ b/tests/routes/mocks.js
@@ -172,6 +172,11 @@ const noHelpline = {
   helpline: '',
 };
 
+const withTaskId = {
+  ...contact1,
+  taskId: 'taskId',
+};
+
 const case1 = {
   status: 'open',
   helpline: 'helpline',
@@ -198,6 +203,7 @@ module.exports = {
   another1,
   another2,
   noHelpline,
+  withTaskId,
   case1,
   case2,
 };

--- a/tests/routes/mocks.js
+++ b/tests/routes/mocks.js
@@ -196,7 +196,7 @@ const withTaskId = {
       refugee: false,
     },
   },
-  twilioWorkerId: 'fake-worker-123',
+  twilioWorkerId: 'not-fake-worker-123',
   helpline: '',
   queueName: '',
   number: '12025550184',

--- a/tests/routes/mocks.js
+++ b/tests/routes/mocks.js
@@ -199,7 +199,7 @@ const withTaskId = {
   twilioWorkerId: 'not-fake-worker-123',
   helpline: '',
   queueName: '',
-  number: '12025550184',
+  number: '11111111111',
   channel: 'chat',
   conversationDuration: 1,
   taskId: 'taskId',

--- a/tests/routes/mocks.js
+++ b/tests/routes/mocks.js
@@ -173,7 +173,35 @@ const noHelpline = {
 };
 
 const withTaskId = {
-  ...contact1,
+  form: {
+    callType: 'Child calling about self',
+    childInformation: {
+      name: {
+        firstName: 'withTaskId',
+        lastName: 'withTaskId',
+      },
+      gender: '',
+      age: '',
+      language: '',
+      nationality: '',
+      ethnicity: '',
+      location: {
+        streetAddress: '',
+        city: '',
+        stateOrCounty: '',
+        postalCode: '',
+        phone1: '',
+        phone2: '',
+      },
+      refugee: false,
+    },
+  },
+  twilioWorkerId: 'fake-worker-123',
+  helpline: '',
+  queueName: '',
+  number: '12025550184',
+  channel: 'chat',
+  conversationDuration: 1,
   taskId: 'taskId',
 };
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-38
This PR is related to https://github.com/tech-matters/flex-plugins/pull/332

Instructions in related PR.

Explanation:
Idempotence for connecting a contact to a case was already implemented ([see hook](https://github.com/tech-matters/hrm/blob/ed929e6d14c0c4bdd062c5122a3a7abd9c861e58/models/contact.js#L76)). This PR also adds `taskId` column to contacts, being an unique identifier sent from the frontend. We are using the Twilio's taskSid for this purpose. If a contact with the given `taskId` already exist, then the subsequent POST will be ignored ([see controller](https://github.com/tech-matters/hrm/blob/ed929e6d14c0c4bdd062c5122a3a7abd9c861e58/controllers/contact-controller.js#L273)).