### PR TITLE
Take accountSid into consideration in the remaining endpoints

### DIFF
--- a/controllers/case-audit-controller.js
+++ b/controllers/case-audit-controller.js
@@ -1,15 +1,18 @@
+const Sequelize = require('sequelize');
 const { getActivity } = require('./activities');
+
+const { Op } = Sequelize;
 
 const CaseAuditController = CaseAudit => {
   const getContactIdsFromCaseAudits = caseAudits => {
     return [...new Set(caseAudits.map(caseAudit => caseAudit.newValue.contacts).flat())];
   };
 
-  const getAuditsForCase = async caseId => {
+  const getAuditsForCase = async (caseId, accountSid) => {
     const queryObject = {
       order: [['createdAt', 'DESC']],
       where: {
-        caseId,
+        [Op.and]: [caseId && { caseId }, accountSid && { accountSid }],
       },
     };
 

--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -27,8 +27,11 @@ const CaseController = (Case, sequelize) => {
   };
 
   const getCase = async (id, accountSid) => {
-    const options = { include: { association: 'connectedContacts' }, where: { accountSid } };
-    const caseFromDB = await Case.findByPk(id, options);
+    const options = {
+      include: { association: 'connectedContacts' },
+      where: { [Op.and]: [{ id }, { accountSid }] },
+    };
+    const caseFromDB = await Case.findOne(options);
 
     if (!caseFromDB) {
       const errorMessage = `Case with id ${id} not found`;

--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -26,8 +26,8 @@ const CaseController = (Case, sequelize) => {
     return createdCase;
   };
 
-  const getCase = async id => {
-    const options = { include: { association: 'connectedContacts' } };
+  const getCase = async (id, accountSid) => {
+    const options = { include: { association: 'connectedContacts' }, where: { accountSid } };
     const caseFromDB = await Case.findByPk(id, options);
 
     if (!caseFromDB) {
@@ -74,14 +74,14 @@ const CaseController = (Case, sequelize) => {
     return { cases, count };
   };
 
-  const updateCase = async (id, body) => {
-    const caseFromDB = await getCase(id);
+  const updateCase = async (id, body, accountSid) => {
+    const caseFromDB = await getCase(id, accountSid);
     const updatedCase = await caseFromDB.update(body);
     return updatedCase;
   };
 
-  const deleteCase = async id => {
-    const caseFromDB = await getCase(id);
+  const deleteCase = async (id, accountSid) => {
+    const caseFromDB = await getCase(id, accountSid);
     await caseFromDB.destroy();
   };
 

--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -233,7 +233,7 @@ const ContactController = Contact => {
   };
 
   const getContacts = async (query, accountSid) => {
-    const queueName = { query };
+    const { queueName } = query;
     const queryObject = {
       order: [['timeOfContact', 'DESC']],
       limit: 10,

--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -232,18 +232,24 @@ const ContactController = Contact => {
     return { count, contacts };
   };
 
-  const getContacts = async query => {
+  const getContacts = async (query, accountSid) => {
+    const queueName = { query };
     const queryObject = {
       order: [['timeOfContact', 'DESC']],
       limit: 10,
     };
-    if (query.queueName) {
-      queryObject.where = {
-        queueName: {
-          [Op.like]: `${query.queueName}%`,
+
+    queryObject.where = {
+      [Op.and]: [
+        accountSid && { accountSid },
+        queueName && {
+          queueName: {
+            [Op.like]: `${queueName}%`,
+          },
         },
-      };
-    }
+      ],
+    };
+
     const contacts = await Contact.findAll(queryObject);
     return contacts.map(e => ({
       id: e.id,
@@ -258,12 +264,17 @@ const ContactController = Contact => {
     }));
   };
 
-  const getContactsById = async contactIds => {
+  const getContactsById = async (contactIds, accountSid) => {
     const queryObject = {
       where: {
-        id: {
-          [Op.in]: contactIds,
-        },
+        [Op.and]: [
+          accountSid && { accountSid },
+          {
+            id: {
+              [Op.in]: contactIds,
+            },
+          },
+        ],
       },
     };
 
@@ -305,8 +316,8 @@ const ContactController = Contact => {
     return contact;
   };
 
-  const connectToCase = async (contactId, caseId) => {
-    const contact = await getContact(contactId);
+  const connectToCase = async (contactId, caseId, accountSid) => {
+    const contact = await getContact(contactId, accountSid);
     const updatedContact = await contact.update({ caseId });
 
     return updatedContact;

--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -305,8 +305,9 @@ const ContactController = Contact => {
     return contact;
   };
 
-  const getContact = async id => {
-    const contact = await Contact.findByPk(id);
+  const getContact = async (id, accountSid) => {
+    const options = { where: { [Op.and]: [{ id }, { accountSid }] } };
+    const contact = await Contact.findOne(options);
 
     if (!contact) {
       const errorMessage = `Contact with id ${id} not found`;

--- a/routes/v0/cases.js
+++ b/routes/v0/cases.js
@@ -22,23 +22,26 @@ casesRouter.post('/', async (req, res) => {
 });
 
 casesRouter.put('/:id', async (req, res) => {
+  const { accountSid } = req;
   const { id } = req.params;
-  const updatedCase = await CaseController.updateCase(id, req.body);
+  const updatedCase = await CaseController.updateCase(id, req.body, accountSid);
   res.json(updatedCase);
 });
 
 casesRouter.delete('/:id', async (req, res) => {
+  const { accountSid } = req;
   const { id } = req.params;
-  await CaseController.deleteCase(id);
+  await CaseController.deleteCase(id, accountSid);
   res.sendStatus(200);
 });
 
 casesRouter.get('/:caseId/activities/', async (req, res) => {
+  const { accountSid } = req;
   const { caseId } = req.params;
-  await CaseController.getCase(caseId);
-  const caseAudits = await CaseAuditController.getAuditsForCase(caseId);
+  await CaseController.getCase(caseId, accountSid);
+  const caseAudits = await CaseAuditController.getAuditsForCase(caseId, accountSid);
   const contactIds = CaseAuditController.getContactIdsFromCaseAudits(caseAudits);
-  const relatedContacts = await ContactController.getContactsById(contactIds);
+  const relatedContacts = await ContactController.getContactsById(contactIds, accountSid);
   const activities = await CaseAuditController.getActivities(caseAudits, relatedContacts);
 
   res.json(activities);

--- a/routes/v0/contacts.js
+++ b/routes/v0/contacts.js
@@ -8,7 +8,8 @@ const CaseController = require('../../controllers/case-controller')(Case, sequel
 const contactsRouter = Router();
 
 contactsRouter.get('/', async (req, res) => {
-  const contacts = await ContactController.getContacts(req.query);
+  const { accountSid } = req;
+  const contacts = await ContactController.getContacts(req.query, accountSid);
   res.json(contacts);
 });
 
@@ -21,10 +22,11 @@ contactsRouter.post('/', async (req, res) => {
 });
 
 contactsRouter.put('/:contactId/connectToCase', async (req, res) => {
+  const { accountSid } = req;
   const { contactId } = req.params;
   const { caseId } = req.body;
-  await CaseController.getCase(caseId);
-  const updatedContact = await ContactController.connectToCase(contactId, caseId);
+  await CaseController.getCase(caseId, accountSid);
+  const updatedContact = await ContactController.connectToCase(contactId, caseId, accountSid);
   res.json(updatedContact);
 });
 

--- a/tests/controllers/case-audit-controller.test.js
+++ b/tests/controllers/case-audit-controller.test.js
@@ -1,3 +1,4 @@
+const Sequelize = require('sequelize');
 const SequelizeMock = require('sequelize-mock');
 const { getActivity } = require('../../controllers/activities');
 const createCaseAuditController = require('../../controllers/case-audit-controller');
@@ -6,6 +7,9 @@ const DBConnectionMock = new SequelizeMock();
 const MockCaseAudit = DBConnectionMock.define('CaseAudits');
 
 jest.mock('../../controllers/activities');
+
+const { Op } = Sequelize;
+const accountSid = 'account-sid';
 
 const CaseAuditController = createCaseAuditController(MockCaseAudit);
 
@@ -89,12 +93,12 @@ test('getAuditsForCase', async () => {
     .spyOn(MockCaseAudit, 'findAll')
     .mockReturnValue(Promise.resolve(caseAudits));
 
-  const result = await CaseAuditController.getAuditsForCase(caseId);
+  const result = await CaseAuditController.getAuditsForCase(caseId, accountSid);
 
   const expectedQuery = {
     order: [['createdAt', 'DESC']],
     where: {
-      caseId,
+      [Op.and]: [{ caseId }, { accountSid }],
     },
   };
 

--- a/tests/controllers/case-controller.test.js
+++ b/tests/controllers/case-controller.test.js
@@ -47,7 +47,7 @@ test('get existing case', async () => {
     include: { association: 'connectedContacts' },
     where: { [Op.and]: [{ id: caseId }, { accountSid }] },
   };
-  expect(findOneSpy).toHaveBeenCalledWith(caseId, options);
+  expect(findOneSpy).toHaveBeenCalledWith(options);
   expect(result).toStrictEqual(caseFromDB);
 });
 

--- a/tests/controllers/case-controller.test.js
+++ b/tests/controllers/case-controller.test.js
@@ -42,9 +42,9 @@ test('get existing case', async () => {
   };
   const findByPkSpy = jest.spyOn(MockCase, 'findByPk').mockImplementation(() => caseFromDB);
 
-  const result = await CaseController.getCase(caseId);
+  const result = await CaseController.getCase(caseId, accountSid);
 
-  const options = { include: { association: 'connectedContacts' } };
+  const options = { include: { association: 'connectedContacts' }, where: { accountSid } };
   expect(findByPkSpy).toHaveBeenCalledWith(caseId, options);
   expect(result).toStrictEqual(caseFromDB);
 });
@@ -53,7 +53,7 @@ test('get non existing case', async () => {
   const nonExistingCaseId = 1;
   jest.spyOn(MockCase, 'findByPk').mockImplementation(() => null);
 
-  await expect(CaseController.getCase(nonExistingCaseId)).rejects.toThrow();
+  await expect(CaseController.getCase(nonExistingCaseId, accountSid)).rejects.toThrow();
 });
 
 describe('Test listCases query params', () => {
@@ -385,7 +385,7 @@ test('update existing case', async () => {
     info: { notes: 'Refugee Child' },
   };
 
-  await CaseController.updateCase(caseId, updateCaseObject);
+  await CaseController.updateCase(caseId, updateCaseObject, accountSid);
 
   expect(updateSpy).toHaveBeenCalledWith(updateCaseObject);
 });
@@ -398,7 +398,9 @@ test('update non existing case', async () => {
     info: { notes: 'Refugee Child' },
   };
 
-  await expect(CaseController.updateCase(nonExsitingCaseId, updateCaseObject)).rejects.toThrow();
+  await expect(
+    CaseController.updateCase(nonExsitingCaseId, updateCaseObject, accountSid),
+  ).rejects.toThrow();
 });
 
 test('delete existing case', async () => {
@@ -414,7 +416,7 @@ test('delete existing case', async () => {
   jest.spyOn(MockCase, 'findByPk').mockImplementation(() => caseFromDB);
   const destroySpy = jest.spyOn(caseFromDB, 'destroy');
 
-  await CaseController.deleteCase(caseId);
+  await CaseController.deleteCase(caseId, accountSid);
 
   expect(destroySpy).toHaveBeenCalled();
 });
@@ -423,5 +425,5 @@ test('delete non existing case', async () => {
   const nonExsitingCaseId = 1;
   jest.spyOn(MockCase, 'findByPk').mockImplementation(() => null);
 
-  await expect(CaseController.deleteCase(nonExsitingCaseId)).rejects.toThrow();
+  await expect(CaseController.deleteCase(nonExsitingCaseId, accountSid)).rejects.toThrow();
 });

--- a/tests/controllers/contact-controller.test.js
+++ b/tests/controllers/contact-controller.test.js
@@ -454,7 +454,7 @@ test('connect contact to case', async () => {
   const updateSpy = jest.spyOn(contactFromDB, 'update');
 
   const updateCaseObject = { caseId };
-  await ContactController.connectToCase(contactId, caseId);
+  await ContactController.connectToCase(contactId, caseId, accountSid);
 
   expect(updateSpy).toHaveBeenCalledWith(updateCaseObject);
 });
@@ -464,5 +464,7 @@ test('connect non existing contact to case', async () => {
   const caseId = 2;
   jest.spyOn(MockContact, 'findByPk').mockImplementation(() => null);
 
-  await expect(ContactController.connectToCase(nonExistingContactId, caseId)).rejects.toThrow();
+  await expect(
+    ContactController.connectToCase(nonExistingContactId, caseId, accountSid),
+  ).rejects.toThrow();
 });

--- a/tests/controllers/contact-controller.test.js
+++ b/tests/controllers/contact-controller.test.js
@@ -14,7 +14,6 @@ const callTypes = {
 const { Op } = Sequelize;
 const DBConnectionMock = new SequelizeMock();
 const MockContact = DBConnectionMock.define('Contacts');
-MockContact.findByPk = jest.fn(); // SequelizeMock doesn't define findByPk by itself
 
 const ContactController = createContactController(MockContact);
 const { queryOnName, queryOnPhone } = ContactController.queries;
@@ -450,7 +449,7 @@ test('connect contact to case', async () => {
     id: contactId,
     update: jest.fn(),
   };
-  jest.spyOn(MockContact, 'findByPk').mockImplementation(() => contactFromDB);
+  jest.spyOn(MockContact, 'findOne').mockImplementation(() => contactFromDB);
   const updateSpy = jest.spyOn(contactFromDB, 'update');
 
   const updateCaseObject = { caseId };
@@ -462,7 +461,7 @@ test('connect contact to case', async () => {
 test('connect non existing contact to case', async () => {
   const nonExistingContactId = 1;
   const caseId = 2;
-  jest.spyOn(MockContact, 'findByPk').mockImplementation(() => null);
+  jest.spyOn(MockContact, 'findOne').mockImplementation(() => null);
 
   await expect(
     ContactController.connectToCase(nonExistingContactId, caseId, accountSid),

--- a/tests/routes/case-audits.test.js
+++ b/tests/routes/case-audits.test.js
@@ -38,7 +38,7 @@ describe('/cases/:caseId/activities route', () => {
   describe('GET', () => {
     let createdCase;
     let nonExistingCaseId;
-    const route = id => `/v0/accounts/accountSid/cases/${id}/activities`;
+    const route = id => `/v0/accounts/account-sid/cases/${id}/activities`;
 
     beforeEach(async () => {
       createdCase = await Case.create(case1);

--- a/tests/routes/contacts.test.js
+++ b/tests/routes/contacts.test.js
@@ -46,7 +46,7 @@ afterAll(async done => {
 afterEach(async () => CaseAudit.destroy(caseAuditsQuery));
 
 describe('/contacts route', () => {
-  const route = '/v0/accounts/accountSid/contacts';
+  const route = '/v0/accounts/account-sid/contacts';
 
   // First test post so database wont be empty
   describe('POST', () => {


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-546

Primary reviewer: @GPaoloni 

This PR is follow up PR to take `accountSid` into consideration when accessing DB data.
The previous PR added this to:
- Search Contacts
- Search Cases
- List All Cases

This PR handles the following actions:
- Get Contacts
- Connect contact to a case
- Update case
- Delete Case
- Get case's activities