### PR TITLE
Add createdBy column to Contacts and Cases tables

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,6 +71,7 @@ async function authorizationMiddleware(req, res, next) {
   if (process.env.NODE_ENV === 'test' && authorization.startsWith('Basic')) {
     const base64Key = Buffer.from(authorization.replace('Basic ', ''), 'base64');
     if (base64Key.toString('ascii') === apiKey) {
+      req.user = new User('test-worker-sid', []);
       return next();
     }
     console.log('API Key authentication failed');

--- a/app.js
+++ b/app.js
@@ -16,7 +16,6 @@ const version = '0.3.6';
 
 console.log(`Starting HRM version ${version}`);
 
-
 swagger.runWhenNotProduction(app);
 
 console.log('After connect attempt');

--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ const version = '0.3.6';
 
 console.log(`Starting HRM version ${version}`);
 
+
 swagger.runWhenNotProduction(app);
 
 console.log('After connect attempt');

--- a/controllers/case-audit-controller.js
+++ b/controllers/case-audit-controller.js
@@ -35,6 +35,7 @@ const CaseAuditController = CaseAudit => {
     contactInstance,
     caseFromDB,
     transaction,
+    createdBy,
   ) => {
     if (!caseFromDB) return;
 
@@ -51,6 +52,7 @@ const CaseAuditController = CaseAudit => {
     const caseAuditRecord = {
       caseId: caseFromDB.dataValues.id,
       twilioWorkerId: contactInstance.dataValues.twilioWorkerId,
+      createdBy,
       accountSid: contactInstance.dataValues.accountSid,
       previousValue,
       newValue,
@@ -59,10 +61,11 @@ const CaseAuditController = CaseAudit => {
     await CaseAudit.create(caseAuditRecord, { transaction });
   };
 
-  const createCaseAuditFromCase = async (previousValue, newValue, transaction) => {
+  const createCaseAuditFromCase = async (previousValue, newValue, transaction, createdBy) => {
     const caseAuditRecord = {
       caseId: newValue.id,
       twilioWorkerId: newValue.twilioWorkerId,
+      createdBy,
       accountSid: newValue.accountSid,
       previousValue,
       newValue,

--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -21,7 +21,7 @@ const CaseController = (Case, sequelize) => {
       helpline: body.helpline,
       status: body.status || 'open',
       twilioWorkerId: body.twilioWorkerId,
-      createdBy: body.createdBy,
+      createdBy: workerSid,
       connectedContacts: [],
       accountSid: accountSid || '',
     };

--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -11,8 +11,11 @@ const searchCasesQuery = fs
   .toString();
 
 const CaseController = (Case, sequelize) => {
-  const createCase = async (body, accountSid) => {
-    const options = { include: { association: 'connectedContacts' } };
+  const createCase = async (body, accountSid, workerSid) => {
+    const options = {
+      include: { association: 'connectedContacts' },
+      context: { workerSid },
+    };
     const caseRecord = {
       info: body.info,
       helpline: body.helpline,
@@ -78,9 +81,10 @@ const CaseController = (Case, sequelize) => {
     return { cases, count };
   };
 
-  const updateCase = async (id, body, accountSid) => {
+  const updateCase = async (id, body, accountSid, workerSid) => {
     const caseFromDB = await getCase(id, accountSid);
-    const updatedCase = await caseFromDB.update(body);
+    const options = { context: { workerSid } };
+    const updatedCase = await caseFromDB.update(body, options);
     return updatedCase;
   };
 

--- a/controllers/case-controller.js
+++ b/controllers/case-controller.js
@@ -18,6 +18,7 @@ const CaseController = (Case, sequelize) => {
       helpline: body.helpline,
       status: body.status || 'open',
       twilioWorkerId: body.twilioWorkerId,
+      createdBy: body.createdBy,
       connectedContacts: [],
       accountSid: accountSid || '',
     };

--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -318,9 +318,10 @@ const ContactController = Contact => {
     return contact;
   };
 
-  const connectToCase = async (contactId, caseId, accountSid) => {
+  const connectToCase = async (contactId, caseId, accountSid, workerSid) => {
     const contact = await getContact(contactId, accountSid);
-    const updatedContact = await contact.update({ caseId });
+    const options = { context: { workerSid } };
+    const updatedContact = await contact.update({ caseId }, options);
 
     return updatedContact;
   };

--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -281,7 +281,7 @@ const ContactController = Contact => {
     return Contact.findAll(queryObject);
   };
 
-  const createContact = async (body, accountSid) => {
+  const createContact = async (body, accountSid, workerSid) => {
     // if a contact has been already created with this taskId, just return it (idempotence on taskId). Should we use a different HTTP code status for this case?
     if (body.taskId) {
       const contact = await Contact.findOne({ where: { taskId: body.taskId } });
@@ -291,7 +291,7 @@ const ContactController = Contact => {
     const contactRecord = {
       rawJson: body.form,
       twilioWorkerId: body.twilioWorkerId || '',
-      createdBy: body.createdBy || '',
+      createdBy: workerSid,
       helpline: body.helpline || '',
       queueName: body.queueName || body.form.queueName,
       number: body.number || '',

--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -291,6 +291,7 @@ const ContactController = Contact => {
     const contactRecord = {
       rawJson: body.form,
       twilioWorkerId: body.twilioWorkerId || '',
+      createdBy: body.createdBy || '',
       helpline: body.helpline || '',
       queueName: body.queueName || body.form.queueName,
       number: body.number || '',

--- a/migrations/20210312163330-add-createdBy.js
+++ b/migrations/20210312163330-add-createdBy.js
@@ -5,6 +5,7 @@ module.exports = {
       return Promise.all([
         queryInterface.addColumn('Contacts', 'createdBy', Sequelize.STRING, { transaction: t }),
         queryInterface.addColumn('Cases', 'createdBy', Sequelize.STRING, { transaction: t }),
+        queryInterface.addColumn('CaseAudits', 'createdBy', Sequelize.STRING, { transaction: t }),
       ]);
     });
   },
@@ -15,6 +16,7 @@ module.exports = {
       return Promise.all([
         queryInterface.removeColumn('Contacts', 'createdBy', { transaction: t }),
         queryInterface.removeColumn('Cases', 'createdBy', { transaction: t }),
+        queryInterface.removeColumn('CaseAudits', 'createdBy', { transaction: t }),
       ]);
     });
   },

--- a/migrations/20210312163330-add-createdBy.js
+++ b/migrations/20210312163330-add-createdBy.js
@@ -1,0 +1,21 @@
+module.exports = {
+  // Return a promise to correctly handle asynchronicity, using queryInterface.sequelize.transaction so that all operations would be executed successfully or none of the changes would be made.
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.addColumn('Contacts', 'createdBy', Sequelize.STRING, { transaction: t }),
+        queryInterface.addColumn('Cases', 'createdBy', Sequelize.STRING, { transaction: t }),
+      ]);
+    });
+  },
+
+  // Return a promise to correctly handle asynchronicity, using queryInterface.sequelize.transaction so that all operations would be executed successfully or none of the changes would be made.
+  down: queryInterface => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeColumn('Contacts', 'createdBy', { transaction: t }),
+        queryInterface.removeColumn('Cases', 'createdBy', { transaction: t }),
+      ]);
+    });
+  },
+};

--- a/models/case-audit.js
+++ b/models/case-audit.js
@@ -1,6 +1,10 @@
 module.exports = (sequelize, DataTypes) => {
   const CaseAudit = sequelize.define('CaseAudit', {
     twilioWorkerId: DataTypes.STRING,
+    createdBy: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     previousValue: DataTypes.JSONB,
     newValue: DataTypes.JSONB,
     /**

--- a/models/case.js
+++ b/models/case.js
@@ -12,7 +12,10 @@ module.exports = (sequelize, DataTypes) => {
     helpline: DataTypes.STRING,
     info: DataTypes.JSONB,
     twilioWorkerId: DataTypes.STRING,
-    createdBy: DataTypes.STRING,
+    createdBy: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     accountSid: DataTypes.STRING,
   });
 

--- a/models/case.js
+++ b/models/case.js
@@ -12,6 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     helpline: DataTypes.STRING,
     info: DataTypes.JSONB,
     twilioWorkerId: DataTypes.STRING,
+    createdBy: DataTypes.STRING,
     accountSid: DataTypes.STRING,
   });
 

--- a/models/case.js
+++ b/models/case.js
@@ -22,6 +22,8 @@ module.exports = (sequelize, DataTypes) => {
   };
 
   Case.afterCreate('auditCaseHook', async (caseInstance, options) => {
+    const { context } = options;
+
     const { CaseAudit } = caseInstance.sequelize.models;
     const { createCaseAuditFromCase } = CaseAuditControllerCreator(CaseAudit);
     const contactIds = await getContactIds(caseInstance);
@@ -31,10 +33,12 @@ module.exports = (sequelize, DataTypes) => {
       contacts: contactIds,
     };
 
-    await createCaseAuditFromCase(previousValue, newValue, options.transaction);
+    await createCaseAuditFromCase(previousValue, newValue, options.transaction, context.workerSid);
   });
 
   Case.afterUpdate('auditCaseHook', async (caseInstance, options) => {
+    const { context } = options;
+
     const { CaseAudit } = caseInstance.sequelize.models;
     const { createCaseAuditFromCase } = CaseAuditControllerCreator(CaseAudit);
     const contactIds = await getContactIds(caseInstance);
@@ -48,7 +52,7 @@ module.exports = (sequelize, DataTypes) => {
       contacts: contactIds,
     };
 
-    await createCaseAuditFromCase(previousValue, newValue, options.transaction);
+    await createCaseAuditFromCase(previousValue, newValue, options.transaction, context.workerSid);
   });
 
   return Case;

--- a/models/contact.js
+++ b/models/contact.js
@@ -54,6 +54,7 @@ module.exports = (sequelize, DataTypes) => {
     rawJson: DataTypes.JSON,
     queueName: DataTypes.STRING,
     twilioWorkerId: DataTypes.STRING,
+    createdBy: DataTypes.STRING,
     helpline: DataTypes.STRING,
     number: DataTypes.STRING,
     channel: DataTypes.STRING,

--- a/models/contact.js
+++ b/models/contact.js
@@ -56,7 +56,10 @@ module.exports = (sequelize, DataTypes) => {
     rawJson: DataTypes.JSON,
     queueName: DataTypes.STRING,
     twilioWorkerId: DataTypes.STRING,
-    createdBy: DataTypes.STRING,
+    createdBy: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     helpline: DataTypes.STRING,
     number: DataTypes.STRING,
     channel: DataTypes.STRING,

--- a/models/contact.js
+++ b/models/contact.js
@@ -22,7 +22,7 @@ const getPreviousAndNewCases = async (contactInstance, transaction) => {
   return [previousCase, newCase];
 };
 
-const auditDisconnectContact = async (contactInstance, caseFromDB, transaction) => {
+const auditDisconnectContact = async (contactInstance, caseFromDB, transaction, workerSid) => {
   const { CaseAudit } = contactInstance.sequelize.models;
   const { createCaseAuditFromContact } = CaseAuditControllerCreator(CaseAudit);
   const initialContactsFunction = (currentContactIds, id) => [...currentContactIds, id];
@@ -32,10 +32,11 @@ const auditDisconnectContact = async (contactInstance, caseFromDB, transaction) 
     contactInstance,
     caseFromDB,
     transaction,
+    workerSid,
   );
 };
 
-const auditConnectContact = async (contactInstance, caseFromDB, transaction) => {
+const auditConnectContact = async (contactInstance, caseFromDB, transaction, workerSid) => {
   const { CaseAudit } = contactInstance.sequelize.models;
   const { createCaseAuditFromContact } = CaseAuditControllerCreator(CaseAudit);
   const initialContactsFunction = (currentContactIds, id) =>
@@ -46,6 +47,7 @@ const auditConnectContact = async (contactInstance, caseFromDB, transaction) => 
     contactInstance,
     caseFromDB,
     transaction,
+    workerSid,
   );
 };
 
@@ -76,9 +78,16 @@ module.exports = (sequelize, DataTypes) => {
 
     if (noCaseIdChange) return;
 
+    const { context } = options;
+
     const [previousCase, newCase] = await getPreviousAndNewCases(contactInstance);
-    await auditDisconnectContact(contactInstance, previousCase, options.transaction);
-    await auditConnectContact(contactInstance, newCase, options.transaction);
+    await auditDisconnectContact(
+      contactInstance,
+      previousCase,
+      options.transaction,
+      context.workerSid,
+    );
+    await auditConnectContact(contactInstance, newCase, options.transaction, context.workerSid);
   });
 
   return Contact;

--- a/routes/v0/cases.js
+++ b/routes/v0/cases.js
@@ -41,16 +41,16 @@ casesRouter.get('/', publicEndpoint, async (req, res) => {
 });
 
 casesRouter.post('/', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { accountSid, user } = req;
 
-  const createdCase = await CaseController.createCase(req.body, accountSid);
+  const createdCase = await CaseController.createCase(req.body, accountSid, user.workerSid);
   res.json(createdCase);
 });
 
 casesRouter.put('/:id', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { accountSid, user } = req;
   const { id } = req.params;
-  const updatedCase = await CaseController.updateCase(id, req.body, accountSid);
+  const updatedCase = await CaseController.updateCase(id, req.body, accountSid, user.workerSid);
   res.json(updatedCase);
 });
 

--- a/routes/v0/contacts.js
+++ b/routes/v0/contacts.js
@@ -22,11 +22,16 @@ contactsRouter.post('/', publicEndpoint, async (req, res) => {
 });
 
 contactsRouter.put('/:contactId/connectToCase', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { accountSid, user } = req;
   const { contactId } = req.params;
   const { caseId } = req.body;
   await CaseController.getCase(caseId, accountSid);
-  const updatedContact = await ContactController.connectToCase(contactId, caseId, accountSid);
+  const updatedContact = await ContactController.connectToCase(
+    contactId,
+    caseId,
+    accountSid,
+    user.workerSid,
+  );
   res.json(updatedContact);
 });
 

--- a/routes/v0/contacts.js
+++ b/routes/v0/contacts.js
@@ -15,9 +15,9 @@ contactsRouter.get('/', publicEndpoint, async (req, res) => {
 
 // example: curl -XPOST -H'Content-Type: application/json' localhost:3000/contacts -d'{"hi": 2}'
 contactsRouter.post('/', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { accountSid, user } = req;
 
-  const contact = await ContactController.createContact(req.body, accountSid);
+  const contact = await ContactController.createContact(req.body, accountSid, user.workerSid);
   res.json(contact);
 });
 

--- a/tests/controllers/contact-builder.js
+++ b/tests/controllers/contact-builder.js
@@ -61,6 +61,11 @@ class ContactBuilder {
     return this;
   }
 
+  withCreatedBy(workerSid) {
+    this.createdBy = workerSid;
+    return this;
+  }
+
   withCreatedAt(createdAt) {
     const date = parseISO(createdAt);
     const timezoneOffset = date.getTimezoneOffset();

--- a/tests/controllers/contact-controller.test.js
+++ b/tests/controllers/contact-controller.test.js
@@ -19,6 +19,7 @@ const ContactController = createContactController(MockContact);
 const { queryOnName, queryOnPhone } = ContactController.queries;
 
 const accountSid = 'account-sid';
+const workerSid = 'worker-sid';
 
 afterEach(() => jest.clearAllMocks());
 
@@ -49,6 +50,7 @@ test('Convert contacts to searchResults', async () => {
     .withNumber('+12025550142')
     .withCallType('Child calling about self')
     .withTwilioWorkerId('twilio-worker-id')
+    .withCreatedBy(workerSid)
     .withCreatedAt('2020-03-10')
     .withTimeOfContact('2020-03-10')
     .withChannel('voice')
@@ -62,6 +64,7 @@ test('Convert contacts to searchResults', async () => {
     .withNumber('Anonymous')
     .withCallType('Child calling about self')
     .withTwilioWorkerId('twilio-worker-id')
+    .withCreatedBy(workerSid)
     .withCreatedAt('2020-03-15')
     .withTimeOfContact('2020-03-15')
     .build();
@@ -453,9 +456,11 @@ test('connect contact to case', async () => {
   const updateSpy = jest.spyOn(contactFromDB, 'update');
 
   const updateCaseObject = { caseId };
-  await ContactController.connectToCase(contactId, caseId, accountSid);
+  const contextObject = { context: { workerSid } };
 
-  expect(updateSpy).toHaveBeenCalledWith(updateCaseObject);
+  await ContactController.connectToCase(contactId, caseId, accountSid, workerSid);
+
+  expect(updateSpy).toHaveBeenCalledWith(updateCaseObject, contextObject);
 });
 
 test('connect non existing contact to case', async () => {
@@ -464,6 +469,6 @@ test('connect non existing contact to case', async () => {
   jest.spyOn(MockContact, 'findOne').mockImplementation(() => null);
 
   await expect(
-    ContactController.connectToCase(nonExistingContactId, caseId, accountSid),
+    ContactController.connectToCase(nonExistingContactId, caseId, accountSid, workerSid),
   ).rejects.toThrow();
 });

--- a/tests/db-init/dump.sql
+++ b/tests/db-init/dump.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.10 (Ubuntu 11.10-1.pgdg18.04+1)
--- Dumped by pg_dump version 11.10 (Ubuntu 11.10-1.pgdg18.04+1)
+-- Dumped from database version 11.11 (Ubuntu 11.11-1.pgdg18.04+1)
+-- Dumped by pg_dump version 11.11 (Ubuntu 11.11-1.pgdg18.04+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -72,7 +72,8 @@ CREATE TABLE public."Cases" (
     helpline character varying(255),
     info jsonb,
     "twilioWorkerId" character varying(255),
-    "accountSid" character varying(255)
+    "accountSid" character varying(255),
+    "createdBy" character varying(255)
 );
 
 
@@ -118,7 +119,8 @@ CREATE TABLE public."Contacts" (
     "caseId" integer,
     "accountSid" character varying(255),
     "timeOfContact" timestamp with time zone,
-    "taskId" character varying(255)
+    "taskId" character varying(255),
+    "createdBy" character varying(255)
 );
 
 
@@ -182,21 +184,21 @@ ALTER TABLE ONLY public."Contacts" ALTER COLUMN id SET DEFAULT nextval('public."
 -- Name: CaseAudits_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."CaseAudits_id_seq"', 753, true);
+SELECT pg_catalog.setval('public."CaseAudits_id_seq"', 1327, true);
 
 
 --
 -- Name: Cases_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."Cases_id_seq"', 655, true);
+SELECT pg_catalog.setval('public."Cases_id_seq"', 1104, true);
 
 
 --
 -- Name: Contacts_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."Contacts_id_seq"', 3028, true);
+SELECT pg_catalog.setval('public."Contacts_id_seq"', 3433, true);
 
 
 --

--- a/tests/db-init/dump.sql
+++ b/tests/db-init/dump.sql
@@ -32,7 +32,8 @@ CREATE TABLE public."CaseAudits" (
     "twilioWorkerId" character varying(255),
     "previousValue" jsonb,
     "newValue" jsonb,
-    "accountSid" character varying(255)
+    "accountSid" character varying(255),
+    "createdBy" character varying(255)
 );
 
 
@@ -184,21 +185,21 @@ ALTER TABLE ONLY public."Contacts" ALTER COLUMN id SET DEFAULT nextval('public."
 -- Name: CaseAudits_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."CaseAudits_id_seq"', 1327, true);
+SELECT pg_catalog.setval('public."CaseAudits_id_seq"', 1338, true);
 
 
 --
 -- Name: Cases_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."Cases_id_seq"', 1104, true);
+SELECT pg_catalog.setval('public."Cases_id_seq"', 1108, true);
 
 
 --
 -- Name: Contacts_id_seq; Type: SEQUENCE SET; Schema: public; Owner: hrm
 --
 
-SELECT pg_catalog.setval('public."Contacts_id_seq"', 3433, true);
+SELECT pg_catalog.setval('public."Contacts_id_seq"', 3435, true);
 
 
 --

--- a/tests/models/case.test.js
+++ b/tests/models/case.test.js
@@ -3,7 +3,8 @@ const { getHook, getMockedCaseInstance } = require('./utils');
 
 const { Case } = models;
 const workerSid = 'worker-sid';
-const options = { transaction: 'transaction-1', context: { workerSid } };
+const transaction= 'transaction-1';
+const options = { transaction, context: { workerSid } };
 
 test('afterCreate hook should create CaseAudit', async () => {
   const hook = getHook(Case, 'afterCreate', 'auditCaseHook');
@@ -35,7 +36,7 @@ test('afterCreate hook should create CaseAudit', async () => {
 
   await hook(caseInstance, options);
 
-  expect(createMethod).toHaveBeenCalledWith(expectedCaseAuditRecord, options);
+  expect(createMethod).toHaveBeenCalledWith(expectedCaseAuditRecord, { transaction });
 });
 
 test('afterUpdate hook should create CaseAudit', async () => {
@@ -75,5 +76,5 @@ test('afterUpdate hook should create CaseAudit', async () => {
 
   await hook(caseInstance, options);
 
-  expect(createMethod).toHaveBeenCalledWith(expectedCaseAuditRecord, options);
+  expect(createMethod).toHaveBeenCalledWith(expectedCaseAuditRecord, { transaction });
 });

--- a/tests/models/case.test.js
+++ b/tests/models/case.test.js
@@ -2,7 +2,8 @@ const models = require('../../models');
 const { getHook, getMockedCaseInstance } = require('./utils');
 
 const { Case } = models;
-const options = { transaction: 'transaction-1' };
+const workerSid = 'worker-sid';
+const options = { transaction: 'transaction-1', context: { workerSid } };
 
 test('afterCreate hook should create CaseAudit', async () => {
   const hook = getHook(Case, 'afterCreate', 'auditCaseHook');
@@ -13,6 +14,7 @@ test('afterCreate hook should create CaseAudit', async () => {
     helpline: 'helpline',
     info: { notes: 'notes' },
     twilioWorkerId: 'worker-id',
+    createdBy: workerSid,
   };
   const contactIds = [1, 2, 3];
   const caseInstance = getMockedCaseInstance({ dataValues, contactIds });
@@ -23,6 +25,7 @@ test('afterCreate hook should create CaseAudit', async () => {
   const expectedCaseAuditRecord = {
     caseId: 3,
     twilioWorkerId: 'worker-id',
+    createdBy: workerSid,
     previousValue: null,
     newValue: {
       ...dataValues,
@@ -44,6 +47,7 @@ test('afterUpdate hook should create CaseAudit', async () => {
     helpline: 'helpline',
     info: { notes: 'notes' },
     twilioWorkerId: 'worker-id',
+    createdBy: workerSid,
   };
   const previousValues = {
     ...dataValues,
@@ -58,6 +62,7 @@ test('afterUpdate hook should create CaseAudit', async () => {
   const expectedCaseAuditRecord = {
     caseId: 3,
     twilioWorkerId: 'worker-id',
+    createdBy: workerSid,
     previousValue: {
       ...previousValues,
       contacts: contactIds,

--- a/tests/models/case.test.js
+++ b/tests/models/case.test.js
@@ -3,7 +3,7 @@ const { getHook, getMockedCaseInstance } = require('./utils');
 
 const { Case } = models;
 const workerSid = 'worker-sid';
-const transaction= 'transaction-1';
+const transaction = 'transaction-1';
 const options = { transaction, context: { workerSid } };
 
 test('afterCreate hook should create CaseAudit', async () => {

--- a/tests/models/contact.test.js
+++ b/tests/models/contact.test.js
@@ -3,7 +3,8 @@ const { getHook, getMockedCaseInstance, getMockedContactInstance } = require('./
 
 const { Contact } = models;
 const workerSid = 'worker-sid';
-const options = { transaction: 'transaction-1', context: { workerSid } };
+const transaction = 'transaction-1';
+const options = { transaction, context: { workerSid } };
 
 test('afterUpdate hook should create two CaseAudit', async () => {
   const hook = getHook(Contact, 'afterUpdate', 'auditCaseHook');
@@ -78,8 +79,8 @@ test('afterUpdate hook should create two CaseAudit', async () => {
   await hook(contactInstance, options);
 
   expect(createMethod).toHaveBeenCalledTimes(2);
-  expect(createMethod).toHaveBeenNthCalledWith(1, expectedPreviousCaseAuditRecord, options);
-  expect(createMethod).toHaveBeenNthCalledWith(2, expectedNewCaseAuditRecord, options);
+  expect(createMethod).toHaveBeenNthCalledWith(1, expectedPreviousCaseAuditRecord, { transaction });
+  expect(createMethod).toHaveBeenNthCalledWith(2, expectedNewCaseAuditRecord, { transaction });
 });
 
 test('afterUpdate hook should create only one CaseAudits', async () => {
@@ -128,7 +129,7 @@ test('afterUpdate hook should create only one CaseAudits', async () => {
   await hook(contactInstance, options);
 
   expect(createMethod).toHaveBeenCalledTimes(1);
-  expect(createMethod).toHaveBeenNthCalledWith(1, expectedNewCaseAuditRecord, options);
+  expect(createMethod).toHaveBeenNthCalledWith(1, expectedNewCaseAuditRecord, { transaction });
 });
 
 test('afterUpdate hook should create no CaseAudits', async () => {

--- a/tests/models/contact.test.js
+++ b/tests/models/contact.test.js
@@ -2,7 +2,8 @@ const models = require('../../models');
 const { getHook, getMockedCaseInstance, getMockedContactInstance } = require('./utils');
 
 const { Contact } = models;
-const options = { transaction: 'transaction-1' };
+const workerSid = 'worker-sid';
+const options = { transaction: 'transaction-1', context: { workerSid } };
 
 test('afterUpdate hook should create two CaseAudit', async () => {
   const hook = getHook(Contact, 'afterUpdate', 'auditCaseHook');
@@ -15,6 +16,7 @@ test('afterUpdate hook should create two CaseAudit', async () => {
     helpline: 'helpline',
     info: { notes: 'notes from previous case' },
     twilioWorkerId,
+    createdBy: workerSid,
   };
   const newCaseDataValues = {
     id: 2,
@@ -22,6 +24,7 @@ test('afterUpdate hook should create two CaseAudit', async () => {
     helpline: 'helpline',
     info: { notes: 'notes from new case' },
     twilioWorkerId,
+    createdBy: workerSid,
   };
   const previousCase = getMockedCaseInstance({
     dataValues: previousCaseDataValues,
@@ -36,6 +39,7 @@ test('afterUpdate hook should create two CaseAudit', async () => {
   const contactInstance = getMockedContactInstance({
     contactId,
     twilioWorkerId,
+    createdBy: workerSid,
     previousCase,
     newCase,
   });
@@ -46,6 +50,7 @@ test('afterUpdate hook should create two CaseAudit', async () => {
   const expectedPreviousCaseAuditRecord = {
     caseId: 1,
     twilioWorkerId,
+    createdBy: workerSid,
     previousValue: {
       ...previousCaseDataValues,
       contacts: [1, 2, contactId],
@@ -59,6 +64,7 @@ test('afterUpdate hook should create two CaseAudit', async () => {
   const expectedNewCaseAuditRecord = {
     caseId: 2,
     twilioWorkerId,
+    createdBy: workerSid,
     previousValue: {
       ...newCaseDataValues,
       contacts: [8, 9],
@@ -87,6 +93,7 @@ test('afterUpdate hook should create only one CaseAudits', async () => {
     helpline: 'helpline',
     info: { notes: 'notes from new case' },
     twilioWorkerId,
+    createdBy: workerSid,
   };
   const newCase = getMockedCaseInstance({
     dataValues: newCaseDataValues,
@@ -96,6 +103,7 @@ test('afterUpdate hook should create only one CaseAudits', async () => {
   const contactInstance = getMockedContactInstance({
     contactId,
     twilioWorkerId,
+    createdBy: workerSid,
     previousCase: null,
     newCase,
   });
@@ -106,6 +114,7 @@ test('afterUpdate hook should create only one CaseAudits', async () => {
   const expectedNewCaseAuditRecord = {
     caseId: 2,
     twilioWorkerId,
+    createdBy: workerSid,
     previousValue: {
       ...newCaseDataValues,
       contacts: [8, 9],
@@ -133,6 +142,7 @@ test('afterUpdate hook should create no CaseAudits', async () => {
     helpline: 'helpline',
     info: { notes: 'notes from previous case' },
     twilioWorkerId,
+    createdBy: workerSid,
   };
   const previousCase = getMockedCaseInstance({
     dataValues: previousCaseDataValues,
@@ -142,6 +152,7 @@ test('afterUpdate hook should create no CaseAudits', async () => {
   const contactInstance = getMockedContactInstance({
     contactId,
     twilioWorkerId,
+    createdBy: workerSid,
     previousCase,
     newCase: previousCase, // didn't change connected case
   });

--- a/tests/models/utils.js
+++ b/tests/models/utils.js
@@ -19,7 +19,7 @@ const getMockedCaseInstance = ({ dataValues, previousValues, contactIds }) => {
   };
 };
 
-const getMockedContactInstance = ({ contactId, twilioWorkerId, previousCase, newCase }) => {
+const getMockedContactInstance = ({ contactId, twilioWorkerId, createdBy, previousCase, newCase }) => {
   const CaseAudit = {
     create: jest.fn(),
   };
@@ -36,6 +36,7 @@ const getMockedContactInstance = ({ contactId, twilioWorkerId, previousCase, new
       id: contactId,
       caseId: newCase.dataValues.id,
       twilioWorkerId,
+      createdBy
     },
     previous,
   };

--- a/tests/models/utils.js
+++ b/tests/models/utils.js
@@ -19,7 +19,13 @@ const getMockedCaseInstance = ({ dataValues, previousValues, contactIds }) => {
   };
 };
 
-const getMockedContactInstance = ({ contactId, twilioWorkerId, createdBy, previousCase, newCase }) => {
+const getMockedContactInstance = ({
+  contactId,
+  twilioWorkerId,
+  createdBy,
+  previousCase,
+  newCase,
+}) => {
   const CaseAudit = {
     create: jest.fn(),
   };
@@ -36,7 +42,7 @@ const getMockedContactInstance = ({ contactId, twilioWorkerId, createdBy, previo
       id: contactId,
       caseId: newCase.dataValues.id,
       twilioWorkerId,
-      createdBy
+      createdBy,
     },
     previous,
   };

--- a/tests/routes/case-audits.test.js
+++ b/tests/routes/case-audits.test.js
@@ -13,6 +13,7 @@ const headers = {
   'Content-Type': 'application/json',
   Authorization: `Basic ${Buffer.from(process.env.API_KEY).toString('base64')}`,
 };
+const workerSid = 'worker-sid';
 
 const { Case, CaseAudit } = models;
 
@@ -39,10 +40,11 @@ describe('/cases/:caseId/activities route', () => {
     let createdCase;
     let nonExistingCaseId;
     const route = id => `/v0/accounts/account-sid/cases/${id}/activities`;
+    const options = { context: { workerSid } };
 
     beforeEach(async () => {
-      createdCase = await Case.create(case1);
-      const caseToBeDeleted = await Case.create(case2);
+      createdCase = await Case.create(case1, options);
+      const caseToBeDeleted = await Case.create(case2, options);
       nonExistingCaseId = caseToBeDeleted.id;
       await caseToBeDeleted.destroy();
     });

--- a/tests/routes/case.test.js
+++ b/tests/routes/case.test.js
@@ -8,6 +8,8 @@ const server = app.listen();
 const request = supertest.agent(server);
 
 const { case1, case2, contact1 } = mocks;
+const workerSid = 'worker-sid';
+const options = { context: { workerSid } };
 
 const headers = {
   'Content-Type': 'application/json',
@@ -99,10 +101,10 @@ describe('/cases route', () => {
       let subRoute;
 
       beforeEach(async () => {
-        createdCase = await Case.create(case1);
+        createdCase = await Case.create(case1, options);
         subRoute = id => `${route}/${id}`;
 
-        const caseToBeDeleted = await Case.create(case2);
+        const caseToBeDeleted = await Case.create(case2, options);
         nonExistingCaseId = caseToBeDeleted.id;
         await caseToBeDeleted.destroy();
       });
@@ -168,10 +170,10 @@ describe('/cases route', () => {
       let subRoute;
 
       beforeEach(async () => {
-        createdCase = await Case.create(case1);
+        createdCase = await Case.create(case1, options);
         subRoute = id => `${route}/${id}`;
 
-        const caseToBeDeleted = await Case.create(case2);
+        const caseToBeDeleted = await Case.create(case2, options);
         nonExistingCaseId = caseToBeDeleted.id;
         await caseToBeDeleted.destroy();
       });
@@ -278,10 +280,10 @@ describe('/cases route', () => {
       const subRoute = `${route}/search`;
 
       beforeEach(async () => {
-        createdCase1 = await Case.create(withHouseholds(case1));
-        createdCase2 = await Case.create(case1);
-        createdCase3 = await Case.create(withPerpetrators(case1));
-        createdContact = await Contact.create(fillNameAndPhone(contact1));
+        createdCase1 = await Case.create(withHouseholds(case1), options);
+        createdCase2 = await Case.create(case1, options);
+        createdCase3 = await Case.create(withPerpetrators(case1), options);
+        createdContact = await Contact.create(fillNameAndPhone(contact1), options);
 
         // Connects createdContact with createdCase2
         createdContact.caseId = createdCase2.id;

--- a/tests/routes/case.test.js
+++ b/tests/routes/case.test.js
@@ -287,7 +287,7 @@ describe('/cases route', () => {
 
         // Connects createdContact with createdCase2
         createdContact.caseId = createdCase2.id;
-        await createdContact.save();
+        await createdContact.save(options);
       });
 
       afterEach(async () => {

--- a/tests/routes/contacts.test.js
+++ b/tests/routes/contacts.test.js
@@ -24,6 +24,7 @@ const headers = {
   'Content-Type': 'application/json',
   Authorization: `Basic ${Buffer.from(process.env.API_KEY).toString('base64')}`,
 };
+const workerSid = 'worker-sid';
 
 const { Contact, Case, CaseAudit } = models;
 
@@ -277,11 +278,12 @@ describe('/contacts route', () => {
     const byGreaterId = (a, b) => b.id - a.id;
 
     beforeEach(async () => {
-      createdContact = await Contact.create(contact1);
-      createdCase = await Case.create(case1);
-      anotherCreatedCase = await Case.create(case2);
-      const contactToBeDeleted = await Contact.create(contact1);
-      const caseToBeDeleted = await Case.create(case1);
+      const options = { context: { workerSid } };
+      createdContact = await Contact.create(contact1, options);
+      createdCase = await Case.create(case1, options);
+      anotherCreatedCase = await Case.create(case2, options);
+      const contactToBeDeleted = await Contact.create(contact1, options);
+      const caseToBeDeleted = await Case.create(case1, options);
 
       existingContactId = createdContact.id;
       existingCaseId = createdCase.id;

--- a/tests/routes/mocks.js
+++ b/tests/routes/mocks.js
@@ -54,6 +54,7 @@ const contact1 = {
     },
   },
   twilioWorkerId: 'fake-worker-123',
+  createdBy: 'worker-sid',
   helpline: '',
   queueName: '',
   number: '12025550184',
@@ -118,6 +119,7 @@ const contact2 = {
     },
   },
   twilioWorkerId: 'fake-worker-987',
+  createdBy: 'worker-sid',
   helpline: '',
   queueName: '',
   number: '12025550184',
@@ -199,6 +201,7 @@ const withTaskId = {
     },
   },
   twilioWorkerId: 'not-fake-worker-123',
+  createdBy: 'worker-sid',
   helpline: '',
   queueName: '',
   number: '11111111111',
@@ -215,6 +218,7 @@ const case1 = {
     notes: 'Child with covid-19',
   },
   twilioWorkerId: 'fake-worker-129',
+  createdBy: 'worker-sid',
   accountSid: 'account-sid',
 };
 
@@ -225,6 +229,7 @@ const case2 = {
     notes: 'Refugee child',
   },
   twilioWorkerId: 'fake-worker-129',
+  createdBy: 'worker-sid',
   accountSid: 'account-sid',
 };
 


### PR DESCRIPTION
This PR is related to https://github.com/tech-matters/flex-plugins/pull/380.

This PR adds `createdBy` column to the DB models in order to preserve the information on who was the creator of the record. The meaning of `twilioWorkerId` (already existing in DB) can be interpreted as "who is the worker that received this Contact". This is the simplest way to integrate the new offline contact behavior without the need of changing the endpoints nor lose any information.

In order for this to work properly for already existing cases, once the migration is run we need to run the following SQL queries:
- To preserve the original creator
  `UPDATE "Contacts" SET "createdBy" = "twilioWorkerId";`
  `UPDATE "Cases" SET "createdBy" = "twilioWorkerId";`
  `UPDATE "CaseAudits" SET "createdBy" = "twilioWorkerId";`

So far the information of "in behalf of who the contact is being added" was not being stored, hence we can't really update `twilioWorkerId` to contain the desired value. Should we do something else here @nickhurlburt?
Also, should `createdBy` be added to case audits too? Asking as I don't know how much value that will add.

After creating 2 offline contacts (one with case):
![Screenshot from 2021-03-12 15-51-48](https://user-images.githubusercontent.com/15805319/110985232-f5d30d00-834a-11eb-8a30-631b348f7704.png)

UPDATE:
`createdBy` column added to CaseAudits table, marked with the `allowNull: false` constraint, in order to prevent missing values (as case audits are filled via hooks, a developer might easily forget about it). `user.workerSid` value (taken from authenticated request object) is added to the `options.context` on each request that fires a case audit event (contact update, case create, case update) so it can be used within the hooks, and provide the `workerSid` as the value for `createdBy` column. 
This is the state of CaseAudits table after creating a case, connecting it to a contact and doing some updates from two different workers:
![Screenshot from 2021-03-18 11-26-29](https://user-images.githubusercontent.com/15805319/111653514-bf800c80-87e6-11eb-9f83-3475e0c741a2.png)

Notes:
- Given that `twilioWorkerId` meaning changed for Contacts and Cases, I don't see the need for keeping it in the CaseAudits column, as it's just replicating the initial value again and again across all the recodrs. Should we remove it?
- Maybe is a good idea to change our model definitions to `allosNull: false` for the cases that null-ish values are disallowed.