### PR TITLE
Do not limit ZM and Beta permissions yet

### DIFF
--- a/permissions/index.js
+++ b/permissions/index.js
@@ -2,16 +2,17 @@ const User = require('./user');
 const { SafeRouter, publicEndpoint } = require('./safe-router');
 const { applyPermissions: applyZmPermissions } = require('./rules/zm');
 const { applyPermissions: applyZaPermissions } = require('./rules/za');
+const { applyPermissions: applyOpenPermissions } = require('./rules/open');
 const { canEditCase } = require('./middlewares');
 
 const applyPermissions = {
-  zm: applyZmPermissions,
+  zm: applyOpenPermissions,
   za: applyZaPermissions,
 };
 
 const setupPermissions = (req, res, next) => {
   if (process.env.NODE_ENV === 'test') {
-    applyZmPermissions(req);
+    applyOpenPermissions(req);
     return next();
   }
 

--- a/permissions/index.js
+++ b/permissions/index.js
@@ -1,6 +1,5 @@
 const User = require('./user');
 const { SafeRouter, publicEndpoint } = require('./safe-router');
-const { applyPermissions: applyZmPermissions } = require('./rules/zm');
 const { applyPermissions: applyZaPermissions } = require('./rules/za');
 const { applyPermissions: applyOpenPermissions } = require('./rules/open');
 const { canEditCase } = require('./middlewares');

--- a/permissions/rules/open.js
+++ b/permissions/rules/open.js
@@ -1,0 +1,92 @@
+const CanCan = require('cancan');
+const { isCounselorWhoCreated, isSupervisor, isCaseOpen } = require('./helpers');
+const Actions = require('../actions');
+const User = require('../user');
+const models = require('../../models');
+
+const cancan = new CanCan();
+const { can, allow } = cancan;
+
+const { Case } = models;
+
+allow(
+  User,
+  Actions.CLOSE_CASE,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(User, Actions.REOPEN_CASE, Case, true);
+
+allow(
+  User,
+  Actions.ADD_NOTE,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(User, Actions.EDIT_NOTE, Case, user => true);
+
+allow(
+  User,
+  Actions.ADD_REFERRAL,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(
+  User,
+  Actions.EDIT_REFERRAL,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(
+  User,
+  Actions.ADD_HOUSEHOLD,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(
+  User,
+  Actions.EDIT_HOUSEHOLD,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(
+  User,
+  Actions.ADD_PERPETRATOR,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(
+  User,
+  Actions.EDIT_PERPETRATOR,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(
+  User,
+  Actions.ADD_INCIDENT,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(
+  User,
+  Actions.EDIT_INCIDENT,
+  Case,
+  (user, caseObj) => true,
+);
+
+allow(User, Actions.EDIT_CASE_SUMMARY, Case, user => true);
+
+const applyPermissions = req => {
+  req.can = can;
+};
+
+module.exports = { applyPermissions };

--- a/permissions/rules/open.js
+++ b/permissions/rules/open.js
@@ -1,6 +1,4 @@
 const CanCan = require('cancan');
-const { isCounselorWhoCreated, isSupervisor, isCaseOpen } = require('./helpers');
-const Actions = require('../actions');
 const User = require('../user');
 const models = require('../../models');
 
@@ -9,81 +7,7 @@ const { can, allow } = cancan;
 
 const { Case } = models;
 
-allow(
-  User,
-  Actions.CLOSE_CASE,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(User, Actions.REOPEN_CASE, Case, true);
-
-allow(
-  User,
-  Actions.ADD_NOTE,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(User, Actions.EDIT_NOTE, Case, user => true);
-
-allow(
-  User,
-  Actions.ADD_REFERRAL,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(
-  User,
-  Actions.EDIT_REFERRAL,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(
-  User,
-  Actions.ADD_HOUSEHOLD,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(
-  User,
-  Actions.EDIT_HOUSEHOLD,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(
-  User,
-  Actions.ADD_PERPETRATOR,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(
-  User,
-  Actions.EDIT_PERPETRATOR,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(
-  User,
-  Actions.ADD_INCIDENT,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(
-  User,
-  Actions.EDIT_INCIDENT,
-  Case,
-  (user, caseObj) => true,
-);
-
-allow(User, Actions.EDIT_CASE_SUMMARY, Case, user => true);
+allow(User, 'manage', Case);
 
 const applyPermissions = req => {
   req.can = can;


### PR DESCRIPTION
We previously added permission support to the HRM.  This PR dials back enforcement of permissions on Beta and ZM on the backend, which we don't want to change yet.  It does this by using the `manage` keyword to grant the user full access.