### PR TITLE
Handle no-diff updates gracefully

### DIFF
--- a/permissions/actions.js
+++ b/permissions/actions.js
@@ -65,16 +65,18 @@ const getActions = (original, updated) => {
   const changes = diff(original, updated, preFilter);
 
   const actions = [];
-  changes.forEach(change => {
-    if (isCloseCase(change)) actions.push(CLOSE_CASE);
-    if (isReopenCase(change)) actions.push(REOPEN_CASE);
-    if (isAddNote(change)) actions.push(ADD_NOTE);
-    if (isAddReferral(change)) actions.push(ADD_REFERRAL);
-    if (isAddHousehold(change)) actions.push(ADD_HOUSEHOLD);
-    if (isAddPerpetrator(change)) actions.push(ADD_PERPETRATOR);
-    if (isAddIncident(change)) actions.push(ADD_INCIDENT);
-    if (isEditCaseSummary(change)) actions.push(EDIT_CASE_SUMMARY);
-  });
+  if (changes) {
+    changes.forEach(change => {
+      if (isCloseCase(change)) actions.push(CLOSE_CASE);
+      if (isReopenCase(change)) actions.push(REOPEN_CASE);
+      if (isAddNote(change)) actions.push(ADD_NOTE);
+      if (isAddReferral(change)) actions.push(ADD_REFERRAL);
+      if (isAddHousehold(change)) actions.push(ADD_HOUSEHOLD);
+      if (isAddPerpetrator(change)) actions.push(ADD_PERPETRATOR);
+      if (isAddIncident(change)) actions.push(ADD_INCIDENT);
+      if (isEditCaseSummary(change)) actions.push(EDIT_CASE_SUMMARY);
+    });
+  }
 
   return actions;
 };


### PR DESCRIPTION
The [deep-diff docs](https://www.npmjs.com/package/deep-diff) state that `diff(...)`:
> Returns either an array of changes or, if there are no changes, `undefined`

This means that if we get a `PUT` where we are making no changes, the current code fails where we call `changes.forEach(...)`.  This checks for `undefined` first.

cc @murilovmachado 