### PR TITLE
Changed rules to determine when a user can transition case status

### DIFF
--- a/permissions/actions.js
+++ b/permissions/actions.js
@@ -2,6 +2,7 @@ const diff = require('deep-diff');
 
 const CLOSE_CASE = 'closeCase';
 const REOPEN_CASE = 'reopenCase';
+const CASE_STATUS_TRANSITION = 'caseStatusTransition';
 const ADD_NOTE = 'addNote';
 const EDIT_NOTE = 'editNote';
 const ADD_REFERRAL = 'addReferral';
@@ -35,7 +36,13 @@ const isReopenCase = change =>
   change.kind === EDITED_PROPERTY &&
   isPathEqual(change.path, ['status']) &&
   change.lhs === 'closed' &&
-  change.rhs === 'open';
+  change.rhs !== 'closed';
+
+const isCaseStatusTransition = change =>
+  change.kind === EDITED_PROPERTY &&
+  isPathEqual(change.path, ['status']) &&
+  change.lhs !== 'closed' &&
+  change.rhs !== 'closed';
 
 const isAddNote = change =>
   isAddOrEditKind(change.kind) && isPathEqual(change.path, ['info', 'notes']);
@@ -69,6 +76,7 @@ const getActions = (original, updated) => {
     changes.forEach(change => {
       if (isCloseCase(change)) actions.push(CLOSE_CASE);
       if (isReopenCase(change)) actions.push(REOPEN_CASE);
+      if (isCaseStatusTransition(change)) actions.push(CASE_STATUS_TRANSITION);
       if (isAddNote(change)) actions.push(ADD_NOTE);
       if (isAddReferral(change)) actions.push(ADD_REFERRAL);
       if (isAddHousehold(change)) actions.push(ADD_HOUSEHOLD);
@@ -85,6 +93,7 @@ module.exports = {
   getActions,
   CLOSE_CASE,
   REOPEN_CASE,
+  CASE_STATUS_TRANSITION,
   ADD_NOTE,
   EDIT_NOTE,
   ADD_REFERRAL,

--- a/permissions/rules/helpers.js
+++ b/permissions/rules/helpers.js
@@ -3,6 +3,6 @@ const isSupervisor = user => user.roles.includes('supervisor');
 const isCounselorWhoCreated = (user, caseObj) =>
   user.workerSid === caseObj.dataValues.twilioWorkerId;
 
-const isCaseOpen = caseObj => caseObj.dataValues.status === 'open';
+const isCaseOpen = caseObj => caseObj.dataValues.status !== 'closed';
 
 module.exports = { isSupervisor, isCounselorWhoCreated, isCaseOpen };

--- a/permissions/rules/za.js
+++ b/permissions/rules/za.js
@@ -21,6 +21,14 @@ allow(User, Actions.REOPEN_CASE, Case, user => isSupervisor(user));
 
 allow(
   User,
+  Actions.CASE_STATUS_TRANSITION,
+  Case,
+  (user, caseObj) =>
+    isSupervisor(user) || (isCaseOpen(caseObj) && isCounselorWhoCreated(user, caseObj)),
+);
+
+allow(
+  User,
   Actions.ADD_NOTE,
   Case,
   (user, caseObj) =>

--- a/permissions/rules/zm.js
+++ b/permissions/rules/zm.js
@@ -19,13 +19,7 @@ allow(
 
 allow(User, Actions.REOPEN_CASE, Case, user => isSupervisor(user));
 
-allow(
-  User,
-  Actions.CASE_STATUS_TRANSITION,
-  Case,
-  (user, caseObj) =>
-    isSupervisor(user) || (isCaseOpen(caseObj) && isCounselorWhoCreated(user, caseObj)),
-);
+allow(User, Actions.CASE_STATUS_TRANSITION, Case, () => false); // Until other statuses than 'open' and 'closed' are added to the ZM specs, we disallow this kind of changes. For more information about this refer to https://github.com/tech-matters/hrm/pull/107#discussion_r608604050
 
 allow(
   User,

--- a/permissions/rules/zm.js
+++ b/permissions/rules/zm.js
@@ -21,6 +21,14 @@ allow(User, Actions.REOPEN_CASE, Case, user => isSupervisor(user));
 
 allow(
   User,
+  Actions.CASE_STATUS_TRANSITION,
+  Case,
+  (user, caseObj) =>
+    isSupervisor(user) || (isCaseOpen(caseObj) && isCounselorWhoCreated(user, caseObj)),
+);
+
+allow(
+  User,
   Actions.ADD_NOTE,
   Case,
   (user, caseObj) =>


### PR DESCRIPTION
This PR is complementary to https://github.com/tech-matters/flex-plugins/pull/412

Primary reviewer: @murilovmachado 

This PR
- Adds a new rule `isCaseStatusTransition` to determine if the status is being updated from a non-closed to another non-closed state (this is done thinking in granularity, a helpline may want anyone to be able to transition but not everyone to close the case, so this rule will play that role. This can be reverted if not desired tho).
- Changes `isOpenCase` helper to `return` true if status is different than `'closed'`.